### PR TITLE
replaced class(obj) == x with is/inherits functions

### DIFF
--- a/R/bm_stats.r
+++ b/R/bm_stats.r
@@ -1,6 +1,6 @@
 ## Basic Statistics
 set.stats <- function(x, set.p = TRUE, set.mu_sigma = TRUE, verbose = getOption("gaston.verbose",TRUE)) {
-  if( is(x)!='bed.matrix' ) stop('x must be an object of class bed.matrix')
+  if (!is(x, "bed.matrix")) stop('x must be an object of class bed.matrix')
   if(!is.logical(set.p) | !is.logical(set.mu_sigma)) 
     stop('set.* arguments must be logical')
 
@@ -83,7 +83,7 @@ set.stats <- function(x, set.p = TRUE, set.mu_sigma = TRUE, verbose = getOption(
 
 ## Basic Statistics, only individuals ---------------------------------------------------------
 set.stats.ped <- function(x, verbose = getOption("gaston.verbose",TRUE)) {
-  if( is(x)!='bed.matrix' ) stop('x must be an object of class bed.matrix')
+  if (!is(x, "bed.matrix")) stop('x must be an object of class bed.matrix')
 
   w.a  <- is.autosome(x@snps$chr)
   w.x  <- is.chr.x(x@snps$chr)

--- a/R/snp_duplicated.r
+++ b/R/snp_duplicated.r
@@ -1,11 +1,12 @@
 
 # seek duplicated by chr pos only for this version
 SNP.duplicated <- function(x, by = "chr:pos") {
-  if(class(x) == "bed.matrix") {
+  if (is(x, "bed.matrix")) {
     x <- x@snps
   }
-  if(class(x) != "data.frame")
+  if (!inherits(x, "data.frame")) {
     stop("x be a bed matrix or a data frame")
+  }
 
   if(by == "id") {
     if(is.null(x$id)) stop("Missing id in x")

--- a/R/snp_match.r
+++ b/R/snp_match.r
@@ -5,17 +5,17 @@ SNP.match <- function(x, table, by = "chr:pos:alleles") {
   if ('alleles' %in% b) 
     b <- c(b[b!='alleles'], 'A1', 'A2')
 
-  if(class(x) == "bed.matrix") {
+  if (is(x, "bed.matrix")) {
     x <- x@snps
   }
 
   x <- x[, b, drop = FALSE]
   # c'est prêt
 
-  if(class(table) == "bed.matrix") {
+  if (is(table, "bed.matrix")) {
     table <- table@snps
   }
-  if(class(x) != "data.frame" | class(table) != "data.frame")
+  if (!inherits(x, "data.frame") || !inherits(table, "data.frame"))
     stop("x and table should be bed matrices or data frames")
   
   .Call('gg_SNPmatch', PACKAGE = "gaston", x, table)

--- a/R/snp_rm_duplicates.r
+++ b/R/snp_rm_duplicates.r
@@ -1,7 +1,7 @@
 ########################### remove duplicated
 
 SNP.rm.duplicates <- function(x, by = "chr:pos", na.keep = TRUE, incomp.rm = TRUE) {
-  if(class(x) != "bed.matrix") stop("x should be a bed.matrix")
+  if (!is(x, "bed.matrix")) stop("x should be a bed.matrix")
   
   b <- strsplit(by,':')[[1]]
   if ('alleles' %in% b) b <- c(b[b!='alleles'], 'A1', 'A2')


### PR DESCRIPTION
I replaced 'class(obj) == x'  with is (for S4) or inherits (for S3) to assert object class.

For example, in `SNP.match` function

if (class(x) != "data.frame") clause would be evaluated as FALSE when your data frame object was created by data.table::fread() since it places 'data.table' class first and then 'data.frame' (i.e., class(data.table) returns  c("data.table", "data.frame")). 

BTW, thanks for the great package!